### PR TITLE
Adding full 'BMC' support for libvirt-managed QEMU VMs

### DIFF
--- a/mr_provisioner/admin/ui/src/components/bmc/bmcEdit.jsx
+++ b/mr_provisioner/admin/ui/src/components/bmc/bmcEdit.jsx
@@ -45,7 +45,11 @@ function BmcEdit_({ fields, fieldErrors, ...props }) {
             >
               <Select
                 required={true}
-                options={[{ name: 'plain' }, { name: 'moonshot' }]}
+                options={[
+                  { name: 'plain' },
+                  { name: 'moonshot' },
+                  { name: 'libvirt_bmc' },
+                ]}
                 value={fields.bmcType}
                 searchKeys={['name']}
                 onChange={props.onChangeBmcType}

--- a/mr_provisioner/admin/ui/src/components/bmc/bmcNew.jsx
+++ b/mr_provisioner/admin/ui/src/components/bmc/bmcNew.jsx
@@ -45,7 +45,11 @@ function BmcNew_({ fields, fieldErrors, ...props }) {
             >
               <Select
                 required={true}
-                options={[{ name: 'plain' }, { name: 'moonshot' }]}
+                options={[
+                  { name: 'plain' },
+                  { name: 'moonshot' },
+                  { name: 'libvirt_bmc' },
+                ]}
                 value={fields.bmcType}
                 searchKeys={['name']}
                 onChange={props.onChangeBmcType}

--- a/mr_provisioner/bmc_types/__init__.py
+++ b/mr_provisioner/bmc_types/__init__.py
@@ -27,3 +27,4 @@ def list_bmc_types():
 
 importlib.import_module('.plain', 'mr_provisioner.bmc_types')
 importlib.import_module('.moonshot', 'mr_provisioner.bmc_types')
+importlib.import_module('.libvirt_bmc', 'mr_provisioner.bmc_types')

--- a/mr_provisioner/bmc_types/libvirt_bmc.py
+++ b/mr_provisioner/bmc_types/libvirt_bmc.py
@@ -1,0 +1,76 @@
+from mr_provisioner.bmc_types import register_bmc_type, BMCType, BMCError
+import requests
+
+
+class LibvirtBMC(BMCType):
+    @property
+    def name(self):
+        return 'libvirt_bmc'
+
+    def validate_bmc_info(self, info):
+        # BMC is validated by admin/controllers.py, checking via API will come
+        # later.
+        return True
+
+    def set_bootdev(self, machine, bootdev):
+        bmc = machine.bmc
+        url = 'http://' + bmc.ip + ':9001/service/' + bmc.name + '/state_controller/'
+        if bootdev == 'pxe':
+            url += 'pxeboot'
+            r = requests.get(url)
+            if r.status_code != 200:
+                raise BMCError("libvirt BMC error on pxeboot : %s" %
+                               str(r.status_code))
+        if bootdev == 'disk':
+            url += 'diskboot'
+            r = requests.get(url)
+            if r.status_code != 200:
+                raise BMCError("libvirt BMC error on diskboot : %s" %
+                               str(r.status_code))
+        if bootdev == 'bios':
+            url += 'defaultboot'
+            r = requests.get(url)
+            if r.status_code != 200:
+                raise BMCError("libvirt BMC error on bios/defaultboot : %s" %
+                               str(r.status_code))
+
+    def set_power(self, machine, power_state):
+        bmc = machine.bmc
+        url = 'http://' + bmc.ip + ':9001/service/' + bmc.name + '/state_controller/'
+        if power_state == 'on' or power_state == 'off':
+            url += 'cyclepower'
+            r = requests.get(url)
+            if r.status_code != 200:
+                raise BMCError("libvirt BMC error on cyclepower : %s" %
+                               str(r.status_code))
+        if power_state == 'reset':
+            url += 'reboot'
+            r = requests.get(url)
+            if r.status_code != 200:
+                raise BMCError("libvirt BMC error on reboot : %s" %
+                               str(r.status_code))
+        if power_state == 'cycle':
+            url += 'force_reset'
+            r = requests.get(url)
+            if r.status_code != 200:
+                raise BMCError("libvirt BMC error on (force_)reset : %s" %
+                               str(r.status_code))
+
+    def get_power(self, machine):
+        bmc = machine.bmc
+        url = 'http://' + bmc.ip + ':9001/service/' + bmc.name + '/state_controller/status'
+        r = requests.get(url)
+        if r.status_code != 200:
+            raise BMCError("libvirt BMC error on getting status : %s" %
+                           str(r.status_code))
+        else:
+            return r.json()['state']
+
+    def deactivate_sol(self, machine):
+        pass
+
+    def get_sol_command(self, machine):
+        return 'Not Implemented'
+
+
+register_bmc_type(LibvirtBMC)

--- a/mr_provisioner/bmc_types/libvirt_bmc.py
+++ b/mr_provisioner/bmc_types/libvirt_bmc.py
@@ -14,7 +14,7 @@ class LibvirtBMC(BMCType):
 
     def set_bootdev(self, machine, bootdev):
         bmc = machine.bmc
-        url = 'http://' + bmc.ip + ':9001/service/' + bmc.name + '/state_controller/'
+        url = 'http://' + bmc.ip + ':9001/service/' + machine.name + '/state_controller/'
         if bootdev == 'pxe':
             url += 'pxeboot'
             r = requests.get(url)
@@ -36,7 +36,7 @@ class LibvirtBMC(BMCType):
 
     def set_power(self, machine, power_state):
         bmc = machine.bmc
-        url = 'http://' + bmc.ip + ':9001/service/' + bmc.name + '/state_controller/'
+        url = 'http://' + bmc.ip + ':9001/service/' + machine.name + '/state_controller/'
         if power_state == 'on' or power_state == 'off':
             url += 'cyclepower'
             r = requests.get(url)
@@ -58,7 +58,7 @@ class LibvirtBMC(BMCType):
 
     def get_power(self, machine):
         bmc = machine.bmc
-        url = 'http://' + bmc.ip + ':9001/service/' + bmc.name + '/state_controller/status'
+        url = 'http://' + bmc.ip + ':9001/service/' + machine.name + '/state_controller/status'
         r = requests.get(url)
         if r.status_code != 200:
             raise BMCError("libvirt BMC error on getting status : %s" %

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 import sys
 import uuid
 import os
 
-
-install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
-requires = [str(ir.req) for ir in install_reqs]
+with open('requirements.txt', 'r') as fd:
+    reqs = fd.readlines()
+    reqs = [r for r in reqs if not r.strip().startswith('#')]
 
 if (3, 0) <= sys.version_info < (3, 3):
     raise SystemExit("Python 3.0, 3.1 and 3.2 are not supported")
@@ -35,7 +34,7 @@ setup(
         "Programming Language :: Python :: 3.4"
     ],
     python_requires='>=3, !=3.0.*, !=3.1.*, !=3.2.*, <4',
-    install_requires=requires,
+    install_requires=reqs,
     extras_require={
     },
     entry_points={


### PR DESCRIPTION
## Adding full 'BMC' support for libvirt-managed QEMU VMs

### Purpose
The purpose of this pull request is to add **full management capabilities** to **libvirt managed VMs** to MrP : that is, power on/off, reboot, hard reset and especially pxebooting and diskbooting.

This comes from a need to **test Ansible scripts to provision machines** without access to physical machines. To provision them requires PXE booting, and currently ipmi_sim (part of OpenIPMI does not allow this). VirtualBMC does need an OpenStack layer to pxeboot (from what I've gathered, correct me if I'm wrong), and we wanted a simpler and easier solution to deploy.

### Instructions
To do all of this, MrP's new BMC type, libvirt_bmc, interfaces with a tool, [libvirt_http_mc](https://github.com/BaptisteGerondeau/libvirt_http_mc), that itself is a RESTlike web interface that needs to run on the libvirt host, and sends commands to virsh.

To make it work one needs to name the VM in MrP exactly as libvirt knows them on the host (as the call is done with machine.name). One can associate multiple machines (VMs) to the libvirt_bmc to manage multiple VMs running on the libvirt's host.

### Notes
Currently libvirt_http_mc does not support digest authentication, but that will eventually come.
Any comments to libvirt_http_mc are welcome as well.

### Working Status
The changes have been tested and do work, modifications to the .js files have been ran through the prettier linter (and committed).