### PR TITLE
Fixing setup.py for pip version 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 import sys
 import uuid
 import os
 
-
-install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
-requires = [str(ir.req) for ir in install_reqs]
+with open('requirements.txt', 'r') as fd:
+    reqs = fd.readlines()
+    reqs = [r for r in reqs if not r.strip().startswith('#')]
 
 if (3, 0) <= sys.version_info < (3, 3):
     raise SystemExit("Python 3.0, 3.1 and 3.2 are not supported")
@@ -35,7 +34,7 @@ setup(
         "Programming Language :: Python :: 3.4"
     ],
     python_requires='>=3, !=3.0.*, !=3.1.*, !=3.2.*, <4',
-    install_requires=requires,
+    install_requires=reqs,
     extras_require={
     },
     entry_points={


### PR DESCRIPTION
The latest pip available hides parse_requirements in pip._internal.req instead of pip.req .
The use of it is highly discouraged : https://github.com/pypa/pip/issues/2286#issuecomment-68285791

So here is an alternative "inspired" by : https://github.com/npwalker/postgresql-metrics/commit/2500307023d4b65ef060340253a8fb04e4cf6d6f