### PR TITLE
Applied the efiboot flag to all chassis bootdev commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Bug fixes:
 
  - ui: set `<title>` for console page based on current machine name
 
+Features:
+
+ - provisioning: options=efiboot handling extended to all bootdev commands (#107)
+
 Docs:
 
  - Upgrade documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 Bug fixes:
 
  - ui: set `<title>` for console page based on current machine name
-
-Features:
-
  - provisioning: options=efiboot handling extended to all bootdev commands (#107)
 
 Docs:

--- a/mr_provisioner/bmc_types/moonshot.py
+++ b/mr_provisioner/bmc_types/moonshot.py
@@ -30,7 +30,7 @@ class MoonshotBMC(BMCType):
         bmc = machine.bmc
 
         opts = None
-        if bootdev == "pxe" and machine.subarch and machine.subarch.efiboot:
+        if machine.subarch and machine.subarch.efiboot:
             opts = "efiboot"
 
         try:

--- a/mr_provisioner/bmc_types/plain.py
+++ b/mr_provisioner/bmc_types/plain.py
@@ -14,7 +14,7 @@ class PlainBMC(BMCType):
         bmc = machine.bmc
 
         opts = None
-        if bootdev == "pxe" and machine.subarch and machine.subarch.efiboot:
+        if machine.subarch and machine.subarch.efiboot:
             opts = "efiboot"
 
         try:


### PR DESCRIPTION
This makes the ipmitool chassis bootdev bios and disk commands use the options=efiboot flag in addition to the ipmitool chassis bootdev pxe command.
This fixes issue #107 

Note that those commands need to be accessed via the [API](https://github.com/mr-provisioner/mr-provisioner/blob/76860a8e60d5158b18e265ff7be6d0f12d118cd4/mr_provisioner/api/v1/controllers.py#L561) at the moment.