### PR TITLE
Update .travis.yml to always use nodejs 9 for the time being

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ matrix:
 
     - language: node_js
       node_js:
-        - node
-        - 7
+        - 9
       install:
         - make -C mr_provisioner/admin/ui dist
       before_script:
@@ -46,8 +45,7 @@ matrix:
 
     - language: node_js
       node_js:
-        - node
-        - 7
+        - 9
       script:
         - make apidocs
       deploy:


### PR DESCRIPTION
Longer term, we should bump the node-sass dependency to a
version that works with nodejs 10 - in both the package-lock.json
and yarn.lock files.

Fixes: #113