### PR TITLE
Include mac address interface property (Fixes: #129).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Features:
 
- -
+ - ui: Include interface mac address as part of the preseed templating options (#129)
 
 Bug fixes:
 

--- a/mr_provisioner/admin/ui/src/components/preseed/preseedEditContents.jsx
+++ b/mr_provisioner/admin/ui/src/components/preseed/preseedEditContents.jsx
@@ -40,7 +40,8 @@ function PreseedEditContents_(props) {
           is a list of interfaces of a machine that have a static IP configured.
           Each interface in the list has a <i>name</i> attribute matching the
           interface identifier, <i>static_ipv4</i> attribute with the configured
-          static IPv4 and a <i>netmask</i> attribute with the netmask.
+          static IPv4 a <i>netmask</i> attribute with the netmask and the
+          interface <i>mac</i> address.
         </dd>
         <dt>
           <code>hostname</code>

--- a/mr_provisioner/preseed/controllers.py
+++ b/mr_provisioner/preseed/controllers.py
@@ -13,7 +13,7 @@ mod = Blueprint('preseed', __name__, template_folder='templates')
 logger = logging.getLogger('preseed')
 
 
-PInterface = namedtuple('object', ['name', 'static_ipv4', 'prefix', 'netmask'])
+PInterface = namedtuple('object', ['name', 'static_ipv4', 'prefix', 'netmask', 'mac'])
 PImage = namedtuple('object', ['filename', 'description', 'known_good'])
 
 
@@ -73,7 +73,8 @@ def get_preseed(machine_id):
     interfaces = [PInterface(name=i.identifier,
                              static_ipv4=i.static_ipv4,
                              prefix=i.network.prefix,
-                             netmask=i.network.netmask) for i in machine.interfaces if i.static_ipv4]
+                             netmask=i.network.netmask,
+                             mac=i.mac) for i in machine.interfaces if i.static_ipv4]
 
     kernel = None
     if machine.kernel:


### PR DESCRIPTION
This change adds the interface mac address property
to the interface object that is passed to the preseed
jinja template rendering.

Fixes #129.
