### PR TITLE
console: use 'monospace' font

### DIFF
--- a/mr_provisioner/admin_legacy/static/assets/css/xterm.css
+++ b/mr_provisioner/admin_legacy/static/assets/css/xterm.css
@@ -38,7 +38,7 @@
 .terminal {
     background-color: #000;
     color: #fff;
-    font-family: courier-new, courier, monospace;
+    font-family: monospace;
     font-feature-settings: "liga" 0;
     position: relative;
 }


### PR DESCRIPTION
This makes web console to use whatever users defined in their
browser as not everyone is a fan of serif fonts.